### PR TITLE
Make null models parallel

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 StatsBase
 Cairo
-Distributions

--- a/src/ProbabilisticNetwork.jl
+++ b/src/ProbabilisticNetwork.jl
@@ -2,7 +2,6 @@ module ProbabilisticNetwork
 
 # Dependencies
 using StatsBase
-using Distributions
 using Cairo
 
 export nestedness, nestedness_axis,

--- a/src/matrix_utils.jl
+++ b/src/matrix_utils.jl
@@ -12,7 +12,8 @@ end
 Generates a random binary matrix based on a probabilistic one
 =#
 function make_bernoulli(A::Array{Float64,2})
-  return map(Float64, rand(size(A)) .<= A)
+  return float64(rand(size(A)) .<= A)
+  # return map(Float64, rand(size(A)) .<= A)
 end
 
 #=

--- a/src/matrix_utils.jl
+++ b/src/matrix_utils.jl
@@ -12,7 +12,7 @@ end
 Generates a random binary matrix based on a probabilistic one
 =#
 function make_bernoulli(A::Array{Float64,2})
-  return map((x) -> float64(rand(Bernoulli(x))), A)
+  return map(Float64, rand(size(A)) .<= A)
 end
 
 #=

--- a/src/matrix_utils.jl
+++ b/src/matrix_utils.jl
@@ -13,6 +13,9 @@ Generates a random binary matrix based on a probabilistic one
 =#
 function make_bernoulli(A::Array{Float64,2})
   return float64(rand(size(A)) .<= A)
+  # This next line will work once 0.4 becomes the current release. For now, the
+  # above works, but with a deprecation warning when used in the release
+  # version.
   # return map(Float64, rand(size(A)) .<= A)
 end
 

--- a/src/nullmodels.jl
+++ b/src/nullmodels.jl
@@ -57,16 +57,7 @@ function nullmodel(A::Array{Float64, 2}; n=1000, max=10000)
       end
     end
     has_enough = (length(b) == n)
-    #has_left = (done < max)
+    has_left = (done < max)
   end
-  # while !(has_enough) & has_left
-  #   done += 1
-  #   trial = make_bernoulli(A)
-  #   if free_species(trial) == 0
-  #     push!(b, trial)
-  #   end
-  #   has_enough = (length(b) == n)
-  #   has_left = (done < max)
-  # end
   return b
 end

--- a/src/nullmodels.jl
+++ b/src/nullmodels.jl
@@ -30,8 +30,12 @@ end
 #=
 Wrapper for null models
 
-Takes a proba matrix, and generates 0/1 networks until there are n done, or
-max have been tried.
+Takes a proba matrix, and generates 0/1 networks until there are n done, or max
+have been tried.
+
+This function will try to run in parallel, because otherwise it takes forever to
+go through all of the potential networks.
+
 =#
 function nullmodel(A::Array{Float64, 2}; n=1000, max=10000)
   max = max < n ? n : max


### PR DESCRIPTION
This should improve efficiency.

But this PR already removes the dependance on `Distributions.jl`, and is therefore o.o.m. faster.